### PR TITLE
SUP-1549.2

### DIFF
--- a/content-modules/primary-content/markup.php
+++ b/content-modules/primary-content/markup.php
@@ -4,7 +4,7 @@
             while ( have_rows('columns') ) :
                 the_row();
         ?>
-            <div class="<?php echo ( get_sub_field('width') != 'auto' ? 'col-md-'.get_sub_field('width') : 'col-md' ); ?><?php echo ( get_sub_field('bottom_padding') != 'none' ? ' kpb-columns__content-column--padding-bottom-'.get_sub_field('bottom_padding') : '' ); ?><?php echo ( get_sub_field('bottom_top') != 'none' ? ' kpb-columns__content-column--padding-top-'.get_sub_field('top_padding') : '' ); ?>">
+            <div class="<?php echo get_sub_field('column_class') ?> <?php echo ( get_sub_field('width') != 'auto' ? 'col-md-'.get_sub_field('width') : 'col-md' ); ?><?php echo ( get_sub_field('bottom_padding') != 'none' ? ' kpb-columns__content-column--padding-bottom-'.get_sub_field('bottom_padding') : '' ); ?><?php echo ( get_sub_field('bottom_top') != 'none' ? ' kpb-columns__content-column--padding-top-'.get_sub_field('top_padding') : '' ); ?>">
                 <?php
 
                 switch (get_sub_field('content_type')):


### PR DESCRIPTION
The core need of this adjustment is to be able to hide the 'Contact Us' title and copy from the https://devbuildingc.wpengine.com/resources/menu-of-strategies/basic-needs/ pages (as one example). This is currently not possible since there is no way to isolate this section with CSS, to hide on print, which is the objective of the ticket. 

The KalaPress page builder already had a 'custom class' field in the admin, but was not outputting to to the front end. This field can be used to add an additional class which can be used to target this 'Contact Us' title and copy so it can be hidden on print, while other content is still visible. 
